### PR TITLE
Update yum in miniconda install step

### DIFF
--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Update yum.
+yum update -y -q
+
 # Install curl to download the miniconda setup script.
 yum install -y curl
 


### PR DESCRIPTION
Makes sure `yum` is updated before proceeding in the miniconda installation step.
