### PR TITLE
Allow `$CORES` to be overridden in the entrypoint script

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,7 +8,7 @@ set -e
 #ulimit -s unlimited
 
 # Get system specs
-export CORES=$(grep -c '^processor' /proc/cpuinfo)
+export CORES=$([[ -z "${CORES+x}" ]] && echo $(grep -c '^processor' /proc/cpuinfo) || echo "${CORES}")
 export HOSTNAME=$(hostname)
 export USER=$(whoami)
 


### PR DESCRIPTION
This will allow the entrypoint to take an external `$CORES` variable and use it. If not set, it will set `$CORES` based on the number of processors it detects. Hopefully, this will workaround this new annoying constraint CPU ( https://github.com/docker/hub-feedback/issues/519#issuecomment-168652934 ) on Docker Hub that is affecting some builds.
