### PR TITLE
tini: Fix RPM install

### DIFF
--- a/docker/install_tini.sh
+++ b/docker/install_tini.sh
@@ -3,5 +3,5 @@
 yum -y update -q
 yum -y install curl grep sed rpm
 TINI_VERSION=`curl https://github.com/krallin/tini/releases/latest | grep -o "/v.*\"" | sed 's:^..\(.*\).$:\1:'`
-rpm -ivh "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.rpm"
+rpm -Uvh "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.rpm"
 yum clean all

--- a/docker/install_tini.sh
+++ b/docker/install_tini.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+yum -y update -q
 yum -y install curl grep sed rpm
 TINI_VERSION=`curl https://github.com/krallin/tini/releases/latest | grep -o "/v.*\"" | sed 's:^..\(.*\).$:\1:'`
 rpm -ivh "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.rpm" && \

--- a/docker/install_tini.sh
+++ b/docker/install_tini.sh
@@ -3,5 +3,5 @@
 yum -y update -q
 yum -y install curl grep sed rpm
 TINI_VERSION=`curl https://github.com/krallin/tini/releases/latest | grep -o "/v.*\"" | sed 's:^..\(.*\).$:\1:'`
-rpm -ivh "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.rpm" && \
+rpm -ivh "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.rpm"
 yum clean all

--- a/docker/install_tini.sh
+++ b/docker/install_tini.sh
@@ -4,4 +4,5 @@ yum -y update -q
 yum -y install curl grep sed rpm
 TINI_VERSION=`curl https://github.com/krallin/tini/releases/latest | grep -o "/v.*\"" | sed 's:^..\(.*\).$:\1:'`
 rpm -Uvh "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.rpm"
+rpm --rebuilddb
 yum clean all


### PR DESCRIPTION
Rebuilds the RPM database after installing tini so that installing with `yum` behaves correctly. Also, adds a `yum update` to the top of the script. Removes some unneeded syntax.
