### PR TITLE
Install tini with `yum` directly

### DIFF
--- a/docker/install_tini.sh
+++ b/docker/install_tini.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 yum -y update -q
-yum -y install curl grep sed rpm
+yum -y install curl grep sed
 TINI_VERSION=`curl https://github.com/krallin/tini/releases/latest | grep -o "/v.*\"" | sed 's:^..\(.*\).$:\1:'`
-rpm -Uvh "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.rpm"
-rpm --rebuilddb
+yum install -y "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.rpm"
 yum clean all


### PR DESCRIPTION
This fixes a warning that is raised by installing with `rpm`. Given that this is simpler and works fine, it seems like the right way to go.
