### PR TITLE
Pin conda-build to 1.20.0

### DIFF
--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -34,6 +34,7 @@ do
     export PATH="${CONDA_PATH}/bin:${OLD_PATH}"
     source activate root
     conda config --set show_channel_urls True
+    echo "conda-build 1.20.0" >> "${CONDA_PATH}/conda-meta/pinned"
 
     # Update and install basic conda dependencies.
     conda update -y --all


### PR DESCRIPTION
Seem to be having trouble building `nanshe` with anything higher. So, we are pinning `conda-build` to 1.20.0.
