### PR TITLE
Unpin `conda-build`

### DIFF
--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -34,7 +34,6 @@ do
     export PATH="${CONDA_PATH}/bin:${OLD_PATH}"
     source activate root
     conda config --set show_channel_urls True
-    echo "conda-build 1.20.0" >> "${CONDA_PATH}/conda-meta/pinned"
 
     # Update and install basic conda dependencies.
     conda update -y --all


### PR DESCRIPTION
Was pinned as we had issues building `nanshe` as mentioned in this PR ( https://github.com/jakirkham/docker_centos_drmaa_conda/pull/18 ). However, that no longer appears to be the case when using `conda-build` version `1.21.5` based on local testing. So, we are going to unpin it again.
