### PR TITLE
Pin conda-build to 1.x

### DIFF
--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -35,6 +35,14 @@ do
     source activate root
     conda config --set show_channel_urls True
 
+    # Pin `conda-build` until `bdist_conda` works.
+    # Please see the linked issue.
+    #
+    # https://github.com/conda/conda-build/issues/1305
+    #
+    touch "${INSTALL_CONDA_PATH}/conda-meta/pinned"
+    echo "conda-build 1.*" >> "${INSTALL_CONDA_PATH}/conda-meta/pinned"
+
     # Update and install basic conda dependencies.
     conda update -y --all
     conda install -y pycrypto


### PR DESCRIPTION
This pins `conda-build` to version `1.x`. Have noticed some issues ( https://github.com/conda/conda-build/issues/1305 ) with `bdist_conda` that are going to cause us pain. So this should help us avoid them until they get sorted.
