### PR TITLE
Switch to conda packages for VCS

### DIFF
--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -6,9 +6,6 @@ yum update -y -q
 # Install curl to download the miniconda setup script.
 yum install -y curl
 
-# Install VCS.
-yum install -y git hg svn
-
 # Install bzip2.
 yum install -y bzip2 tar
 
@@ -52,6 +49,11 @@ do
 
     # Install python bindings to DRMAA.
     conda install -y drmaa
+
+    # Install common VCS packages.
+    conda install -y git
+    conda install -y mercurial
+    conda install -y svn
 
     # Clean out all unneeded intermediates.
     conda clean -yitps


### PR DESCRIPTION
Was running into some issues with the old `git` provided by `yum`. So it made more sense to just switch to the `conda` package for this. That is what we have done here.
