### PR TITLE
Use `conda-forge`

### DIFF
--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -32,6 +32,9 @@ do
     source activate root
     conda config --set show_channel_urls True
 
+    # Add conda-forge to our channels.
+    conda config --add channels conda-forge
+
     # Pin `conda-build` until `bdist_conda` works.
     # Please see the linked issue.
     #


### PR DESCRIPTION
Uses `conda-forge` to get dependencies. As later images do this anyways, we should save some effort by dealing with switching the common packages to the ones from `conda-forge` here first.
