### PR TITLE
Raise install errors

### DIFF
--- a/docker/install_tini.sh
+++ b/docker/install_tini.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 yum update -y -q
 yum install -y -q curl grep sed
 TINI_VERSION=`curl https://github.com/krallin/tini/releases/latest | grep -o "/v.*\"" | sed 's:^..\(.*\).$:\1:'`

--- a/gridengine/install_ge.sh
+++ b/gridengine/install_ge.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 export USER=$(whoami)
 export SGE_CONFIG_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export SGE_ROOT=$SGE_CONFIG_DIR
@@ -53,7 +55,6 @@ echo "Submit a simple job to make sure the submission system really works."
 
 mkdir /tmp/test_gridengine &>/dev/null
 pushd /tmp/test_gridengine &>/dev/null
-set -e
 
 echo "-------------- test.sh --------------"
 echo -e '#!/bin/bash\necho "stdout"\necho "stderr" 1>&2' | tee test.sh
@@ -79,7 +80,6 @@ grep stderr test.sh.e* &>/dev/null
 
 rm test.sh*
 
-set +e
 popd &>/dev/null
 rm -rf /tmp/test_gridengine &>/dev/null
 # Put everything back the way it was.

--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Update yum.
 yum update -y -q
 


### PR DESCRIPTION
Have all install scripts error out if any step goes wrong. This way if some install step does get messed up we can be sure it doesn't result in a faulty deployment.