### PR TITLE
Fix install errors

### DIFF
--- a/docker/install_tini.sh
+++ b/docker/install_tini.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 yum update -y -q
 yum install -y -q curl grep sed
 TINI_VERSION=`curl https://github.com/krallin/tini/releases/latest | grep -o "/v.*\"" | sed 's:^..\(.*\).$:\1:'`

--- a/gridengine/install_ge.sh
+++ b/gridengine/install_ge.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 export USER=$(whoami)
 export SGE_CONFIG_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export SGE_ROOT=$SGE_CONFIG_DIR
@@ -53,7 +55,6 @@ echo "Submit a simple job to make sure the submission system really works."
 
 mkdir /tmp/test_gridengine &>/dev/null
 pushd /tmp/test_gridengine &>/dev/null
-set -e
 
 echo "-------------- test.sh --------------"
 echo -e '#!/bin/bash\necho "stdout"\necho "stderr" 1>&2' | tee test.sh
@@ -79,7 +80,6 @@ grep stderr test.sh.e* &>/dev/null
 
 rm test.sh*
 
-set +e
 popd &>/dev/null
 rm -rf /tmp/test_gridengine &>/dev/null
 # Put everything back the way it was.

--- a/gridengine/install_ge.sh
+++ b/gridengine/install_ge.sh
@@ -6,7 +6,7 @@ export USER=$(whoami)
 export SGE_CONFIG_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export SGE_ROOT=$SGE_CONFIG_DIR
 echo $SGE_CONFIG_DIR
-sed -i -r "s/^(127.0.0.1\s)(localhost\.localdomain\slocalhost)/\1localhost localhost.localdomain ${HOSTNAME} /" /etc/hosts
+sed -i -r "s/^(127.0.0.1\s)(localhost\.localdomain\slocalhost)/\1localhost localhost.localdomain ${HOSTNAME} /" /etc/hosts || true
 cp /etc/resolv.conf /etc/resolv.conf.orig
 echo "domain ${HOSTNAME}" >> /etc/resolv.conf
 # Update everything.

--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Update yum.
 yum update -y -q
 

--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -25,7 +25,7 @@ do
 
     # Download and install `conda`.
     cd /usr/share/miniconda
-    curl "http://repo.continuum.io/miniconda/Miniconda${PYTHON_VERSION}-latest-Linux-x86_64.sh" > "miniconda${PYTHON_VERSION}.sh"
+    curl -L "https://repo.continuum.io/miniconda/Miniconda${PYTHON_VERSION}-latest-Linux-x86_64.sh" > "miniconda${PYTHON_VERSION}.sh"
     bash "miniconda${PYTHON_VERSION}.sh" -b -p "${INSTALL_CONDA_PATH}"
     rm "miniconda${PYTHON_VERSION}.sh"
 

--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -57,7 +57,11 @@ do
 
     # Install common VCS packages.
     conda install -qy git
-    conda install -qy mercurial
+    if [ "${PYTHON_VERSION}" == "2" ]
+    then
+        # Mercurial is Python 2 only.
+        conda install -qy mercurial
+    fi
     conda install -qy svn
 
     # Clean out all unneeded intermediates.


### PR DESCRIPTION
Uses PR ( https://github.com/jakirkham/docker_centos_drmaa_conda/pull/28 ) to raise any and all installation errors that come up breaking the build. Suppresses errors from a problematic `sed` command during the SGE install. Updates the Miniconda download to use HTTPS. Limits installation of `mercurial` to Python 2 environments as it does not support Python 3.