### PR TITLE
Unpin `conda-build`

### DIFF
--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -37,13 +37,8 @@ do
     # Add conda-forge to our channels.
     conda config --add channels conda-forge
 
-    # Pin `conda-build` until `bdist_conda` works.
-    # Please see the linked issue.
-    #
-    # https://github.com/conda/conda-build/issues/1305
-    #
+    # Provide an empty pinning file should it be needed.
     touch "${INSTALL_CONDA_PATH}/conda-meta/pinned"
-    echo "conda-build 1.*" >> "${INSTALL_CONDA_PATH}/conda-meta/pinned"
 
     # Update and install basic conda dependencies.
     conda update -qy --all


### PR DESCRIPTION
Reverts https://github.com/jakirkham/docker_centos_drmaa_conda/pull/22
Closes https://github.com/nanshe-org/docker_nanshe/pull/22
Related https://github.com/nanshe-org/nanshe/pull/434

This releases the `conda-build` 1 pinning so as to start using `conda-build` 2. As this was mainly put in due to issues with `bdist_conda`, this can be merged as long as those are fixed. We keep an empty pinning file around though in case things depend on writing to it.