### PR TITLE
Switch to the USNO's time service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:6.6
 MAINTAINER John Kirkham <jakirkham@gmail.com>
 
 # Add a timestamp for the build. Also, bust the cache.
-ADD http://www.timeapi.org/utc/now /opt/docker/etc/timestamp
+ADD http://tycho.usno.navy.mil/timer.html /opt/docker/etc/timestamp
 
 RUN echo "exclude=*.i386 *.i686" >> /etc/yum.conf && \
     yum update -y -q && \


### PR DESCRIPTION
Fixes https://github.com/jakirkham/docker_centos_drmaa_conda/issues/31

It appears that timeapi.org has been taken offline and the domain is up for grabs. To still ensure the cache is busted at the beginning of the Docker build, this switches to the USNO's time service to get the time since the last epoch. This should allow us to still bust the cache and save the time when the image was built.