### PR TITLE
Pin to Miniconda 4.2.12

### DIFF
--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -25,7 +25,7 @@ do
 
     # Download and install `conda`.
     cd /usr/share/miniconda
-    curl -L "https://repo.continuum.io/miniconda/Miniconda${PYTHON_VERSION}-latest-Linux-x86_64.sh" > "miniconda${PYTHON_VERSION}.sh"
+    curl -L "https://repo.continuum.io/miniconda/Miniconda${PYTHON_VERSION}-4.2.12-Linux-x86_64.sh" > "miniconda${PYTHON_VERSION}.sh"
     bash "miniconda${PYTHON_VERSION}.sh" -b -p "${INSTALL_CONDA_PATH}"
     rm "miniconda${PYTHON_VERSION}.sh"
 


### PR DESCRIPTION
Adding this pinning of the Miniconda version to ensure that we still are using Python 3.5. This is needed as we have not fully upgraded to Python 3.6 yet.