### PR TITLE
Update to the latest Python minor version

### DIFF
--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -40,7 +40,10 @@ do
     # Provide an empty pinning file should it be needed.
     touch "${INSTALL_CONDA_PATH}/conda-meta/pinned"
 
-    # Update and install basic conda dependencies.
+    # Update conda and other basic dependencies.
+    conda update -qy --all
+
+    # Install some other conda relevant packages.
     conda update -qy --all
     conda install -qy pycrypto
     conda install -qy conda-build

--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -43,6 +43,9 @@ do
     # Update conda and other basic dependencies.
     conda update -qy --all
 
+    # Update to latest Python minor version.
+    conda install -qy "python=${PYTHON_VERSION}"
+
     # Install some other conda relevant packages.
     conda update -qy --all
     conda install -qy pycrypto


### PR DESCRIPTION
Should allow us to use Python 3.6 in the Python 3 Miniconda environment to leverage the newest Python features as needed.