### PR TITLE
Use the CentOS 6 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:6.6
+FROM centos:6
 MAINTAINER John Kirkham <jakirkham@gmail.com>
 
 # Add a timestamp for the build. Also, bust the cache.


### PR DESCRIPTION
Instead of using the CentOS 6.6 image (with minor version pinned), drop the minor version and just use the CentOS 6 image. Initially we had pinned the minor version to the oldest version of CentOS 6 available as a stock image. This was done to try to be as close as possible to the CentOS version on our cluster at the time (CentOS 6.3). However really just using the CentOS 6 image seems to be good enough, which is what conda-forge does. Also our cluster is now on CentOS 7. Finally the CentOS 6.6 image doesn't seem to be getting CVE fixes as it hasn't been updated in 8 months. The CentOS 6 image has been updated in the last month to address CVE related issues. As such it seems reasonable for us to drop the minor version and just the CentOS 6 image.