### PR TITLE
Switch to Python 3 by default

### DIFF
--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -74,6 +74,6 @@ do
     ln -s "${INSTALL_CONDA_PATH}/bin/conda"  "/usr/local/bin/conda${PYTHON_VERSION}"
 done
 
-# Set the conda2 environment as the default.
+# Set the conda3 environment as the default.
 # This should be removed in the future.
-ln -s /opt/conda2 /opt/conda
+ln -s /opt/conda3 /opt/conda


### PR DESCRIPTION
As everything we use upwards in the stack works on Python 2 and Python 3, there is no reason to prefer Python 2 when Python 3 is the future.