### PR TITLE
Use conda-forge's tini

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,5 @@ ENV PATH=/opt/conda/bin:$PATH \
 ADD docker /usr/share/docker
 RUN /usr/share/docker/install_tini.sh
 
-ENTRYPOINT [ "/usr/bin/tini", "--", "/usr/share/docker/entrypoint.sh" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/usr/share/docker/entrypoint.sh" ]
 CMD [ "/bin/bash" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ ENV PATH=/opt/conda/bin:$PATH \
     CONDA_ENV_PATH=/opt/conda
 
 ADD docker /usr/share/docker
-RUN /usr/share/docker/install_tini.sh
 
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/usr/share/docker/entrypoint.sh" ]
 CMD [ "/bin/bash" ]

--- a/docker/install_tini.sh
+++ b/docker/install_tini.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -e
-
-yum update -y -q
-yum install -y -q curl grep sed
-TINI_VERSION=`curl https://github.com/krallin/tini/releases/latest | grep -o "/v.*\"" | sed 's:^..\(.*\).$:\1:'`
-yum install -y -q "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.rpm"
-yum clean all -y -q

--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -53,6 +53,9 @@ do
     conda install -qy anaconda-client
     conda install -qy jinja2
 
+    # Install tini for the Docker container init process.
+    conda install -qy tini
+
     # Install python bindings to DRMAA.
     conda install -qy drmaa
 


### PR DESCRIPTION
Instead of installing prebuilt binaries from the `tini` project, install and use `conda` packages for `tini` from `conda-forge`. We actually maintain the `tini` builds on conda-forge ourself and they are built from source with the intention of using them on CentOS 6. So are a better fit for this image. Should also cut a few things from being installed with `yum`.