### PR TITLE
Upgrade to Miniconda 4.3.21

### DIFF
--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -17,16 +17,23 @@ yum install -y -q libSM libXext libXrender
 # Clean out yum.
 yum clean all -y -q
 
+export MINICONDA_VERSION="4.2.12"
+export MINICONDA2_CHECKSUM="c8b836baaa4ff89192947e4b1a70b07e"
+export MINICONDA3_CHECKSUM="d0c7c71cc5659e54ab51f2005a8d96f3"
+
 # Install everything for both environments.
 export OLD_PATH="${PATH}"
 for PYTHON_VERSION in 2 3;
 do
     export INSTALL_CONDA_PATH="/opt/conda${PYTHON_VERSION}"
-    export MINICONDA_VERSION="4.2.12"
+    export MINICONDA_CHECKSUM="\${MINICONDA${PYTHON_VERSION}_CHECKSUM}"
+    eval export MINICONDA_CHECKSUM=``${MINICONDA_CHECKSUM}``
 
     # Download and install `conda`.
     cd /usr/share/miniconda
     curl -L "https://repo.continuum.io/miniconda/Miniconda${PYTHON_VERSION}-${MINICONDA_VERSION}-Linux-x86_64.sh" > "miniconda${PYTHON_VERSION}.sh"
+    openssl md5 "miniconda${PYTHON_VERSION}.sh"
+    openssl md5 "miniconda${PYTHON_VERSION}.sh" | grep "${MINICONDA_CHECKSUM}"
     bash "miniconda${PYTHON_VERSION}.sh" -b -p "${INSTALL_CONDA_PATH}"
     rm "miniconda${PYTHON_VERSION}.sh"
 

--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -17,9 +17,9 @@ yum install -y -q libSM libXext libXrender
 # Clean out yum.
 yum clean all -y -q
 
-export MINICONDA_VERSION="4.2.12"
-export MINICONDA2_CHECKSUM="c8b836baaa4ff89192947e4b1a70b07e"
-export MINICONDA3_CHECKSUM="d0c7c71cc5659e54ab51f2005a8d96f3"
+export MINICONDA_VERSION="4.3.21"
+export MINICONDA2_CHECKSUM="7097150146dd3b83c805223663ebffcc"
+export MINICONDA3_CHECKSUM="c1c15d3baba15bf50293ae963abef853"
 
 # Install everything for both environments.
 export OLD_PATH="${PATH}"

--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -22,10 +22,11 @@ export OLD_PATH="${PATH}"
 for PYTHON_VERSION in 2 3;
 do
     export INSTALL_CONDA_PATH="/opt/conda${PYTHON_VERSION}"
+    export MINICONDA_VERSION="4.2.12"
 
     # Download and install `conda`.
     cd /usr/share/miniconda
-    curl -L "https://repo.continuum.io/miniconda/Miniconda${PYTHON_VERSION}-4.2.12-Linux-x86_64.sh" > "miniconda${PYTHON_VERSION}.sh"
+    curl -L "https://repo.continuum.io/miniconda/Miniconda${PYTHON_VERSION}-${MINICONDA_VERSION}-Linux-x86_64.sh" > "miniconda${PYTHON_VERSION}.sh"
     bash "miniconda${PYTHON_VERSION}.sh" -b -p "${INSTALL_CONDA_PATH}"
     rm "miniconda${PYTHON_VERSION}.sh"
 


### PR DESCRIPTION
To start with Python 3.6 and `conda` 4.3, switch to Miniconda 4.3.21. This version has been pretty reliable for us at `conda-forge`. So should be good here. Also checksum the download and do some cleanup to make upgrading in the future easier.