### PR TITLE
Include basic fonts in the Docker image

### DIFF
--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -14,6 +14,9 @@ yum install -y -q bzip2 tar
 # Install dependencies of conda's Qt4.
 yum install -y -q libSM libXext libXrender
 
+# Install basic fonts (needed by things like Graphviz).
+yum install -y -q urw-fonts
+
 # Clean out yum.
 yum clean all -y -q
 


### PR DESCRIPTION
Things like Graphviz expect to be able to find fonts on the system. However we do not currently include any fonts in the system install. This adds some basic fonts to the system so that Graphviz and other things can display text properly.