### PR TITLE
Remove the `.conda` directory in `root`'s home

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN for PYTHON_VERSION in 2 3; do \
         export INSTALL_CONDA_PATH="/opt/conda${PYTHON_VERSION}" && \
         . ${INSTALL_CONDA_PATH}/bin/activate root && \
         conda install -qy -n root drmaa && \
-        conda clean -tipsy ; \
+        conda clean -tipsy && \
+        rm -rf ~/.conda ; \
     done
 
 ADD entrypoint.sh /usr/share/docker/entrypoint_2.sh


### PR DESCRIPTION
When installing and upgrading packages with `conda`, it creates a `.conda` directory in `root`'s home. This is used by `conda` as a fallback if it lacks permissions to `conda`'s install prefix. However leaving `root`'s `.conda` directory could mess with a user created one while running the container. So this cleans up the `.conda` directory in `root`'s home after all of the installing and upgrading is complete. This should make the container more usable with Singularity.