### PR TITLE
Cleanup `.pki` directory after SGE install

### DIFF
--- a/gridengine/install_ge.sh
+++ b/gridengine/install_ge.sh
@@ -89,3 +89,4 @@ cp /etc/resolv.conf.orig /etc/resolv.conf
 cp ${SGE_ROOT}/default/common/act_qmaster.orig ${SGE_ROOT}/default/common/act_qmaster
 # Clean yum so we don't have a bunch of junk left over from our build.
 yum clean all -y -q
+rm -rf ~/.pki


### PR DESCRIPTION
Appears that the `yum install` steps used by SGE result in generating the `.pki` directory in `root`'s home again despite having removed it before after downloading Miniconda. To make sure the `.pki` directory is not included in the Docker commit for the SGE install layer, remove it at the very end of the `install_ge.sh` script.