### PR TITLE
Make sure to deactivate `conda`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,10 @@ ENV SGE_CONFIG_DIR=/usr/share/gridengine \
 
 RUN for PYTHON_VERSION in 2 3; do \
         export INSTALL_CONDA_PATH="/opt/conda${PYTHON_VERSION}" && \
-        . ${INSTALL_CONDA_PATH}/bin/activate root && \
+        . ${INSTALL_CONDA_PATH}/bin/activate && \
         conda install -qy -n root drmaa && \
         conda clean -tipsy && \
+        . ${INSTALL_CONDA_PATH}/bin/deactivate && \
         rm -rf ~/.conda ; \
     done
 


### PR DESCRIPTION
When looping through the `conda` installs, make sure to deactivate each one after we are done using that `conda` installation. Also drop `root` from `activate` as `root` is already assumed if no environment name is specified.