### PR TITLE
Fix sourcing of `conda.sh`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV SGE_CONFIG_DIR=/usr/share/gridengine \
 
 RUN for PYTHON_VERSION in 2 3; do \
         export INSTALL_CONDA_PATH="/opt/conda${PYTHON_VERSION}" && \
-        . /opt/conda/etc/profile.d/conda.sh && \
+        . "${INSTALL_CONDA_PATH}/etc/profile.d/conda.sh" && \
         conda activate base && \
         conda install -qy drmaa && \
         conda clean -tipsy && \


### PR DESCRIPTION
Fixes an issue in PR ( https://github.com/jakirkham/docker_centos_drmaa_conda/pull/49 ).

Should be grabbing the relevant `conda.sh` for each `conda` install. However was reusing the same one from the Python 3-based `conda` install. May not matter much as it is a generic shell script (not Python code), which defines shell functions. Still good to handle this correctly going forward.